### PR TITLE
Refactor classified ad list to use JCR query

### DIFF
--- a/src/components/ClassifiedAdList/default.server.tsx
+++ b/src/components/ClassifiedAdList/default.server.tsx
@@ -1,20 +1,20 @@
 import { RenderChildren, jahiaComponent, server } from "@jahia/javascript-modules-library";
-import type { ClassifiedAdSummary, Maybe } from "../../utils/classifieds.js";
-import {
-  formatDate,
-  formatPrice,
-  mapGraphQLNodeToClassified,
-  normalizeLabel,
-  parseNumber,
-  resolveFolderReference,
-  toStringValue,
-} from "../../utils/classifieds.js";
-import {
-  CLASSIFIED_ADS_BY_PATH_QUERY,
-  CLASSIFIED_ADS_BY_UUID_QUERY,
-} from "../../graphql/classifiedAds.js";
+import { JCRQueryBuilder, gqlNodesQueryString } from "../../commons/libs/jcrQueryBuilder/index.js";
+import type { JCRQueryConfig, RenderNodeProps } from "../../commons/libs/jcrQueryBuilder/types.js";
+import type { Maybe } from "../../utils/classifieds.js";
+import { parseNumber, resolveFolderReference, toStringValue } from "../../utils/classifieds.js";
 import classes from "./component.module.css";
 import type { RenderContext, Resource } from "org.jahia.services.render";
+
+const NODE_PATH_BY_UUID_QUERY = /* GraphQL */ `
+  query ClassifiedAdListFolderPath($uuid: String!) {
+    jcr {
+      nodeById(uuid: $uuid) {
+        path
+      }
+    }
+  }
+`;
 
 type ClassifiedAdListProps = {
   teaser?: Maybe<string>;
@@ -42,7 +42,6 @@ type GraphQLExecutor = {
   fn: GraphQLExecutorFn;
   scope: unknown;
 };
-
 
 const getGraphQLExecutor = (context: ClassifiedAdListContext): GraphQLExecutor | undefined => {
   const scopes: Array<{ scope: unknown; fn: unknown }> = [];
@@ -107,85 +106,46 @@ const executeGraphQL = async (
   }
 };
 
-const applyFilters = (
-  items: ClassifiedAdSummary[],
-  filters: {
-    filterCategory?: Maybe<string>;
-    filterAvailability?: Maybe<string>;
-    minPrice?: Maybe<number | string>;
-    maxPrice?: Maybe<number | string>;
-  },
-) => {
-  const min = parseNumber(filters.minPrice);
-  const max = parseNumber(filters.maxPrice);
-  return items.filter((item) => {
-    if (filters.filterCategory && item.category && item.category !== filters.filterCategory) {
-      return false;
-    }
-    if (
-      filters.filterAvailability &&
-      item.availability &&
-      item.availability !== filters.filterAvailability
-    ) {
-      return false;
-    }
-    if (min !== undefined && item.price !== undefined && item.price < min) {
-      return false;
-    }
-    if (max !== undefined && item.price !== undefined && item.price > max) {
-      return false;
-    }
-    return true;
-  });
+const resolveWorkspace = (renderContext?: RenderContext): JCRQueryConfig["workspace"] => {
+  const workspaceName = renderContext && typeof renderContext.getWorkspace === "function"
+    ? renderContext.getWorkspace()
+    : "default";
+  return workspaceName === "live" || workspaceName === "LIVE" ? "LIVE" : "EDIT";
 };
 
-const sortItems = (items: ClassifiedAdSummary[], orderBy: Maybe<string>) => {
-  const sorted = [...items];
-  switch (orderBy) {
-    case "datePostedAsc":
-      sorted.sort((a, b) => {
-        const aTime = a.datePosted ? new Date(a.datePosted).getTime() : 0;
-        const bTime = b.datePosted ? new Date(b.datePosted).getTime() : 0;
-        return aTime - bTime;
-      });
-      break;
-    case "priceAsc":
-      sorted.sort((a, b) => {
-        const aPrice = a.price ?? Number.POSITIVE_INFINITY;
-        const bPrice = b.price ?? Number.POSITIVE_INFINITY;
-        return aPrice - bPrice;
-      });
-      break;
-    case "priceDesc":
-      sorted.sort((a, b) => {
-        const aPrice = a.price ?? Number.NEGATIVE_INFINITY;
-        const bPrice = b.price ?? Number.NEGATIVE_INFINITY;
-        return bPrice - aPrice;
-      });
-      break;
-    case "datePostedDesc":
-    default:
-      sorted.sort((a, b) => {
-        const aTime = a.datePosted ? new Date(a.datePosted).getTime() : 0;
-        const bTime = b.datePosted ? new Date(b.datePosted).getTime() : 0;
-        return bTime - aTime;
-      });
-      break;
-  }
-  return sorted;
-};
-
-const formatFilterPrice = (value: Maybe<number | string>, locale: string): string | undefined => {
-  const numeric = parseNumber(value);
-  if (numeric !== undefined) {
+const resolveComponentUuid = (resource?: Resource): string => {
+  const node = typeof resource?.getNode === "function" ? resource.getNode() : undefined;
+  if (node && typeof node.getIdentifier === "function") {
     try {
-      return new Intl.NumberFormat(locale, { maximumFractionDigits: 2 }).format(numeric);
-    } catch {
-      return String(numeric);
+      return node.getIdentifier();
+    } catch (error) {
+      console.warn("[ClassifiedAdList] Unable to resolve component identifier", error);
     }
   }
-  const stringValue = toStringValue(value);
-  return stringValue && stringValue.trim().length > 0 ? stringValue.trim() : undefined;
+  return "classified-ad-list";
+};
+
+const resolveFallbackPath = (resource?: Resource): string | undefined => {
+  const node = typeof resource?.getNode === "function" ? resource.getNode() : undefined;
+  if (!node) {
+    return undefined;
+  }
+  const parent = typeof node.getParent === "function" ? node.getParent() : undefined;
+  if (parent && typeof parent.getPath === "function") {
+    try {
+      return parent.getPath();
+    } catch (error) {
+      console.warn("[ClassifiedAdList] Unable to resolve parent path", error);
+    }
+  }
+  if (typeof node.getPath === "function") {
+    try {
+      return node.getPath();
+    } catch (error) {
+      console.warn("[ClassifiedAdList] Unable to resolve node path", error);
+    }
+  }
+  return undefined;
 };
 
 jahiaComponent(
@@ -199,76 +159,46 @@ jahiaComponent(
     const { renderContext, currentResource } = context;
     const locale = currentResource?.getLocale().toString() ?? "en";
     const editMode = renderContext?.isEditMode?.() ?? false;
+    const executor = getGraphQLExecutor(context);
 
     const maxItems = parseNumber(props.maxItems) ?? 12;
     const folderIds = resolveFolderReference(props.folder);
-    if (process.env.NODE_ENV !== "production") {
-      console.info("[ClassifiedAdList] Resolved folder reference", {
-        raw: props.folder,
-        folderIds,
-      });
-    }
-    const executor = getGraphQLExecutor(context);
 
-    let fetchError: unknown;
-    let fetched: ClassifiedAdSummary[] | null = null;
+    let startNodePath = folderIds.path ?? resolveFallbackPath(currentResource);
 
-    if (executor && (folderIds.path || folderIds.uuid)) {
+    if (!startNodePath && folderIds.uuid && executor) {
       try {
-        if (process.env.NODE_ENV !== "production") {
-          console.info("[ClassifiedAdList] Fetching classifieds", {
-            folderIds,
-            locale,
-            strategy: folderIds.path ? "path" : "uuid",
-          });
-        }
-        const variables = {
-          language: locale,
-          ...(folderIds.path ? { path: folderIds.path } : {}),
-          ...(folderIds.uuid ? { uuid: folderIds.uuid } : {}),
-        };
-    const query = folderIds.path ? CLASSIFIED_ADS_BY_PATH_QUERY : CLASSIFIED_ADS_BY_UUID_QUERY;
-        const response = (await executeGraphQL(executor, query, variables)) as Record<string, unknown>;
-        const data = (response?.data as Record<string, unknown>)?.jcr as Record<string, unknown>;
-        const container = folderIds.path
-          ? (data?.nodeByPath as Record<string, unknown>)
-          : (data?.nodeById as Record<string, unknown>);
-        const raw = (container?.children as Record<string, unknown>)?.nodes as Maybe<Array<Record<string, unknown>>>;
-        fetched =
-          raw
-            ?.map((node) => mapGraphQLNodeToClassified(node as Record<string, unknown>))
-            .filter((item): item is ClassifiedAdSummary => !!item) ?? [];
+        const response = (await executeGraphQL(executor, NODE_PATH_BY_UUID_QUERY, {
+          uuid: folderIds.uuid,
+        })) as Record<string, unknown>;
+        const data = response?.data as { jcr?: { nodeById?: { path?: string } } } | undefined;
+        startNodePath = data?.jcr?.nodeById?.path ?? undefined;
       } catch (error) {
-        fetchError = error;
-        console.error("[ClassifiedAdList] Failed to fetch classifieds", error);
-      }
-    } else if (props.folder && !executor && editMode) {
-      fetchError = new Error("GraphQL executor unavailable in this context");
-    }
-
-    let items = fetched ?? [];
-    if (items.length > 0) {
-      items = applyFilters(items, {
-        filterCategory: props.filterCategory,
-        filterAvailability: props.filterAvailability,
-        minPrice: props.minPrice,
-        maxPrice: props.maxPrice,
-      });
-      items = sortItems(items, props.orderBy ?? "datePostedDesc");
-      items = items.slice(0, maxItems);
-      if (process.env.NODE_ENV !== "production") {
-        console.info("[ClassifiedAdList] Prepared classified items", {
-          total: fetched?.length ?? 0,
-          afterFilters: items.length,
-          folderIds,
-        });
+        console.error("[ClassifiedAdList] Unable to resolve folder path from uuid", error);
       }
     }
 
-    // Use toStringValue to safely normalize teaser content for dangerouslySetInnerHTML
+    const workspace = resolveWorkspace(renderContext);
+    const componentUuid = resolveComponentUuid(currentResource);
+    const viewName = toStringValue(props["j:subNodesView"]) ?? "card";
+
+    const builderConfig: JCRQueryConfig = {
+      workspace,
+      type: "classadnt:classifiedAd",
+      startNodePath: startNodePath ?? "/",
+      criteria: "j:lastPublished",
+      sortDirection: "desc",
+      categories: [],
+      excludeNodes: [],
+      uuid: componentUuid,
+      subNodeView: viewName,
+      language: locale,
+      limit: maxItems,
+      offset: 0,
+    };
+
     const teaser = (() => {
       try {
-        // toStringValue imported from utils/classifieds.js
         const raw = toStringValue(props.teaser);
         return raw && raw.trim().length > 0 ? raw : undefined;
       } catch {
@@ -276,123 +206,91 @@ jahiaComponent(
       }
     })();
 
-    const minPriceLabel = formatFilterPrice(props.minPrice, locale);
-    const maxPriceLabel = formatFilterPrice(props.maxPrice, locale);
+    let nodes: RenderNodeProps[] = [];
+    let fetchError: unknown;
 
-    try {
-      if (process.env.NODE_ENV === 'development') {
-        console.log("[ClassifiedAdList] Props:", props);
-        console.log("[ClassifiedAdList] Items:", items);
-        console.log("[ClassifiedAdList] Teaser:", teaser);
-        console.log("[ClassifiedAdList] CSS classes:", classes);
-        console.log("[ClassifiedAdList] maxItems:", maxItems, typeof maxItems);
-        if (items.length > 0) {
-          console.log("[ClassifiedAdList] First item sample:", items[0]);
-          console.log("[ClassifiedAdList] item.id type:", typeof items[0].id);
-          console.log("[ClassifiedAdList] item.formattedPrice sample:", formatPrice(items[0].price, items[0].priceCurrency, items[0].priceUnit, locale));
-        }
-      }
-
-      // Helper to ensure className is always a string
-      const safeClass = (value: unknown): string =>
-        typeof value === "string" ? value : "";
-
-      return (
-        <section className={classes.list}>
-          {typeof teaser === "string" && (
-            <div
-              className={safeClass(classes?.teaser) || "fallback-teaser"}
-              dangerouslySetInnerHTML={{ __html: teaser }}
-            />
-          )}
-
-          <div className={classes.controls}>
-            {typeof maxItems === "number" && <span>Showing up to {maxItems} items</span>}
-            <div className={classes.filters}>
-              {props.filterCategory && <span className={safeClass(classes.filterBadge)}>Category: {normalizeLabel(props.filterCategory)}</span>}
-              {props.filterAvailability && (
-                <span className={safeClass(classes.filterBadge)}>Availability: {normalizeLabel(props.filterAvailability)}</span>
-              )}
-              {minPriceLabel && <span className={safeClass(classes.filterBadge)}>Min price: {minPriceLabel}</span>}
-              {maxPriceLabel && <span className={safeClass(classes.filterBadge)}>Max price: {maxPriceLabel}</span>}
-            </div>
-          </div>
-
-          {items.length > 0 ? (
-            <div className={classes.items}>
-              {items.map((item, index) => {
-                const formattedPrice = formatPrice(item.price, item.priceCurrency, item.priceUnit, locale);
-                const posted = formatDate(item.datePosted, locale);
-                const locationLabel = [item.locationCity, item.locationCountry].filter(Boolean).join(", ");
-                if (renderContext) {
-                  if (item.uuid) {
-                    server.render.addCacheDependency({ uuid: item.uuid }, renderContext);
-                  } else if (item.path) {
-                    server.render.addCacheDependency({ path: item.path }, renderContext);
-                  }
-                }
-                const itemHref = item.path;
-                // Guard key: only string or number, fallback to index
-                const key = (typeof item.id === "string" || typeof item.id === "number") ? item.id : `fallback-${index}`;
-                if (process.env.NODE_ENV === 'development') {
-                  // Dev logging for key, id, formattedPrice, classes
-                  console.log("[ClassifiedAdList] Rendering item:", {
-                    id: item.id,
-                    key,
-                    formattedPrice,
-                    classes,
-                  });
-                }
-                return (
-                  <article key={key} className={safeClass(classes?.card) || "fallback-card"}>
-                    <h3 className={safeClass(classes?.cardTitle) || "fallback-card-title"}>{item.title}</h3>
-                    <div className={safeClass(classes?.cardMeta) || "fallback-card-meta"}>
-                      {item.category && <span>{normalizeLabel(item.category)}</span>}
-                      {item.availability && <span>{normalizeLabel(item.availability)}</span>}
-                      {locationLabel && <span>{locationLabel}</span>}
-                      {item.featured && <span className={safeClass(classes.filterBadge)}>Featured</span>}
-                    </div>
-                    {formattedPrice && (
-                      <div className={safeClass(classes?.cardPrice) || "fallback-card-price"}>{formattedPrice}</div>
-                    )}
-                    <div className={safeClass(classes?.cardFooter) || "fallback-card-footer"}>
-                      {posted && <span>Posted {posted}</span>}
-                      {itemHref && (
-                        <a className={safeClass(classes?.cardLink) || "fallback-card-link"} href={itemHref}>
-                          View
-                        </a>
-                      )}
-                    </div>
-                  </article>
-                );
-              })}
-            </div>
-          ) : (
-            <>
-              {fetchError && editMode && (
-                <div className={classes.error}>
-                  Unable to fetch items from the selected folder. {String(fetchError)}
-                </div>
-              )}
-              <RenderChildren />
-              {editMode && (
-                <p className={classes.hint}>
-                  Add classified tiles under this list or ensure the target folder contains published classified ads.
-                </p>
-              )}
-            </>
-          )}
-        </section>
-      );
-    } catch (error) {
-      console.error("[ClassifiedAdList] Render error:", error);
-      return (
-        <section className={classes.list}>
-          <div style={{ color: "red", padding: "1rem", border: "1px solid red" }}>
-            Failed to render Classified Ad List component.
-          </div>
-        </section>
-      );
+    if (!startNodePath && props.folder) {
+      fetchError = new Error("Unable to resolve target folder path");
     }
+
+    if (!fetchError && executor && startNodePath) {
+      try {
+        const builder = new JCRQueryBuilder(builderConfig);
+        const { jcrQuery, cacheDependency } = builder.build();
+        if (renderContext) {
+          server.render.addCacheDependency({ flushOnPathMatchingRegexp: cacheDependency }, renderContext);
+        }
+
+        const query = gqlNodesQueryString({
+          isRenderEnabled: true,
+          limit: builderConfig.limit,
+          offset: builderConfig.offset,
+        });
+
+        const response = (await executeGraphQL(executor, query, {
+          workspace: builderConfig.workspace,
+          query: jcrQuery,
+          language: builderConfig.language,
+          view: builderConfig.subNodeView,
+        })) as Record<string, unknown>;
+
+        const gqlNodes = (response?.data as Record<string, unknown>)?.jcr as
+          | { nodesByQuery?: { nodes?: Array<{ uuid?: string; renderedContent?: { output?: string } }> } }
+          | undefined;
+
+        nodes =
+          gqlNodes?.nodesByQuery?.nodes?.map((node) => ({
+            uuid: typeof node.uuid === "string" ? node.uuid : "",
+            html: node.renderedContent?.output ?? "",
+          })) ?? [];
+
+        if (renderContext) {
+          for (const node of gqlNodes?.nodesByQuery?.nodes ?? []) {
+            const uuid = typeof node.uuid === "string" ? node.uuid : undefined;
+            if (uuid) {
+              server.render.addCacheDependency({ uuid }, renderContext);
+            }
+          }
+        }
+      } catch (error) {
+        fetchError = error;
+        console.error("[ClassifiedAdList] Failed to execute JCR query", error);
+      }
+    } else if (!executor && props.folder && editMode) {
+      fetchError = new Error("GraphQL executor unavailable in this context");
+    }
+
+    return (
+      <section className={classes.list}>
+        {typeof teaser === "string" && (
+          <div className={classes.teaser} dangerouslySetInnerHTML={{ __html: teaser }} />
+        )}
+
+        {nodes.length > 0 ? (
+          <div className={classes.items}>
+            {nodes.map((node, index) => (
+              <div
+                key={node.uuid || `classified-ad-${index}`}
+                dangerouslySetInnerHTML={{ __html: node.html }}
+              />
+            ))}
+          </div>
+        ) : (
+          <>
+            {fetchError && editMode && (
+              <div className={classes.error}>
+                Unable to fetch items from the selected folder. {String(fetchError)}
+              </div>
+            )}
+            <RenderChildren />
+            {editMode && (
+              <p className={classes.hint}>
+                Select a target folder containing published classified ads or create manual tiles below.
+              </p>
+            )}
+          </>
+        )}
+      </section>
+    );
   },
 );


### PR DESCRIPTION
## Summary
- refactor the ClassifiedAdList server component to resolve its start folder, build a JCR query, and fetch rendered card views for ads
- remove the previous manual filtering/sorting logic so the component simply renders the query results and edit-mode fallback

## Testing
- yarn lint *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_b_68d13bdf43a4832c9257c7b1993429ce