### PR TITLE
Add client-rendered back button to classified ad full page

### DIFF
--- a/settings/locales/en.json
+++ b/settings/locales/en.json
@@ -34,6 +34,7 @@
   "classifiedAd.fullPage.gallery.placeholderAlt": "Placeholder image",
   "classifiedAd.fullPage.section.atAGlance": "At a glance",
   "classifiedAd.fullPage.action.visitListing": "Visit listing",
+  "classifiedAd.fullPage.action.back": "Back",
   "classifiedAd.fullPage.labels.categories": "Categories:",
   "classifiedAd.fullPage.labels.tags": "Tags:",
   "classifiedAd.price.suffix.month": "/month",

--- a/settings/locales/fr.json
+++ b/settings/locales/fr.json
@@ -34,6 +34,7 @@
   "classifiedAd.fullPage.gallery.placeholderAlt": "Image de remplacement",
   "classifiedAd.fullPage.section.atAGlance": "En un coup d'œil",
   "classifiedAd.fullPage.action.visitListing": "Voir l'annonce",
+  "classifiedAd.fullPage.action.back": "Retour",
   "classifiedAd.fullPage.labels.categories": "Catégories :",
   "classifiedAd.fullPage.labels.tags": "Étiquettes :",
   "classifiedAd.price.suffix.month": "/mois",

--- a/src/components/ClassifiedAd/fullPage.client.tsx
+++ b/src/components/ClassifiedAd/fullPage.client.tsx
@@ -1,0 +1,43 @@
+import { useCallback } from "react";
+
+import classes from "./fullPage.module.css";
+
+type Props = {
+  label: string;
+  className?: string;
+  fallbackUrl?: string;
+};
+
+const FullPageClient = ({ label, className, fallbackUrl }: Props) => {
+  const handleBack = useCallback(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    if (window.history.length > 1) {
+      window.history.back();
+      return;
+    }
+
+    if (fallbackUrl) {
+      window.location.href = fallbackUrl;
+      return;
+    }
+
+    if (typeof document !== "undefined" && document.referrer) {
+      window.location.href = document.referrer;
+    }
+  }, [fallbackUrl]);
+
+  return (
+    <button
+      type="button"
+      onClick={handleBack}
+      className={[classes.backButton, className].filter(Boolean).join(" ")}
+    >
+      {label}
+    </button>
+  );
+};
+
+export default FullPageClient;

--- a/src/components/ClassifiedAd/fullPage.module.css
+++ b/src/components/ClassifiedAd/fullPage.module.css
@@ -30,11 +30,44 @@
   gap: 0.75rem;
 }
 
+.titleRow {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
 .title {
   margin: 0;
   font-size: clamp(2rem, 4vw, 2.8rem);
   line-height: 1.1;
   color: #0f172a;
+}
+
+.backButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.45rem 1rem;
+  border-radius: 999px;
+  border: 1px solid #cbd5f5;
+  background: #eef2ff;
+  color: #1e3a8a;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.backButton:hover,
+.backButton:focus-visible {
+  background: #e0e7ff;
+  border-color: #a5b4fc;
+  color: #1d4ed8;
+}
+
+.backButton:focus-visible {
+  outline: 2px solid #6366f1;
+  outline-offset: 2px;
 }
 
 .meta {

--- a/src/components/ClassifiedAd/fullPage.server.tsx
+++ b/src/components/ClassifiedAd/fullPage.server.tsx
@@ -19,6 +19,7 @@ import {
   toStringValue,
 } from "../../utils/classifieds.js";
 import GalleryClient from "../../commons/Gallery.client";
+import FullPageClient from "./fullPage.client.js";
 
 import classes from "./fullPage.module.css";
 import type { JCRNodeWrapper } from "org.jahia.services.content";
@@ -192,7 +193,16 @@ jahiaComponent(
         <div className={classes.container}>
           <header className={classes.header}>
             <div className={classes.titleBlock}>
-              <h1 className={classes.title}>{heading}</h1>
+              <div className={classes.titleRow}>
+                <Island
+                  component={FullPageClient}
+                  props={{
+                    label: t("classifiedAd.fullPage.action.back"),
+                    className: classes.backButton,
+                  }}
+                />
+                <h1 className={classes.title}>{heading}</h1>
+              </div>
               <div className={classes.meta}>
                 {datePosted && (
                   <span>{t("classifiedAd.meta.postedOn", { date: datePosted })}</span>


### PR DESCRIPTION
## Summary
- add a client island to the full page classified ad view that renders a back button next to the title
- style the header to accommodate the new control and translate the button label in English and French

## Testing
- yarn lint *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_b_68d3df75bc68832ca13d193457591f99